### PR TITLE
Equality nodes with cg and lit

### DIFF
--- a/axiom-profiler-GUI/src/results/filters/filter_chain.rs
+++ b/axiom-profiler-GUI/src/results/filters/filter_chain.rs
@@ -21,6 +21,7 @@ pub struct FilterChain {
 const DEFAULT_FILTER_CHAIN: &[Filter] = &[
     Filter::IgnoreTheorySolving,
     Filter::MaxInsts(DEFAULT_NODE_COUNT),
+    Filter::PruneEqualityNodes,
 ];
 
 #[derive(Properties, PartialEq)]

--- a/axiom-profiler-GUI/src/results/filters/graph_filters.rs
+++ b/axiom-profiler-GUI/src/results/filters/graph_filters.rs
@@ -26,6 +26,7 @@ pub enum Filter {
     ShowMatchingLoopSubgraph,
     IgnoreEqualityNodes,
     PruneEqualityNodes,
+    IgnoreChainEqualityNodes,
 }
 
 impl Display for Filter {
@@ -79,6 +80,7 @@ impl Display for Filter {
             }
             Self::IgnoreEqualityNodes => write!(f, "Hiding all equality nodes"),
             Self::PruneEqualityNodes => write!(f, "Hiding all equality nodes without visible ancestor or descendant that is an instantiation node"),
+            Self::IgnoreChainEqualityNodes => write!(f, "Hiding all equality nodes with exactly one child and one parent"),
         }
     }
 }
@@ -107,6 +109,7 @@ impl Filter {
             Filter::ShowMatchingLoopSubgraph => graph.show_matching_loop_subgraph(),
             Filter::IgnoreEqualityNodes => graph.hide_equality_nodes(),
             Filter::PruneEqualityNodes => graph.prune_equality_nodes(),
+            Filter::IgnoreChainEqualityNodes => graph.ignore_chain_equality_nodes(),
         }
         FilterOutput::None
     }
@@ -211,6 +214,10 @@ impl Component for GraphFilters {
             let callback = ctx.props().add_filters.clone();
             Callback::from(move |_| callback.emit(vec![Filter::PruneEqualityNodes]))
         };
+        let ignore_chain_equalities = {
+            let callback = ctx.props().add_filters.clone();
+            Callback::from(move |_| callback.emit(vec![Filter::IgnoreChainEqualityNodes]))
+        };
         html! {
             <div>
                 <h2>{"Add (optional) filters:"}</h2>
@@ -257,6 +264,10 @@ impl Component for GraphFilters {
                 <div>
                     <label for="prune_equalities">{"Prune equality nodes"}</label>
                     <button onclick={prune_equalities} id="prune_equalities">{"Add"}</button>
+                </div>
+                <div>
+                    <label for="ignore_chain_equalities">{"Ignore chain equality nodes"}</label>
+                    <button onclick={ignore_chain_equalities} id="ignore_chain_equalities">{"Add"}</button>
                 </div>
                 {if !self.selected_nodes.is_empty() {
                     html! {

--- a/axiom-profiler-GUI/src/results/filters/graph_filters.rs
+++ b/axiom-profiler-GUI/src/results/filters/graph_filters.rs
@@ -24,6 +24,7 @@ pub enum Filter {
     ShowLongestPath(NodeIndex),
     // SelectNthMatchingLoop(usize),
     ShowMatchingLoopSubgraph,
+    IgnoreEqualityNodes,
 }
 
 impl Display for Filter {
@@ -75,6 +76,7 @@ impl Display for Filter {
             Self::ShowMatchingLoopSubgraph => {
                 write!(f, "Showing all potential matching loops")
             }
+            Self::IgnoreEqualityNodes => write!(f, "Hiding all equality nodes")
         }
     }
 }
@@ -101,6 +103,7 @@ impl Filter {
             Filter::ShowLongestPath(nidx) => return FilterOutput::LongestPath(graph.show_longest_path_through(nidx)),
             // Filter::SelectNthMatchingLoop(n) => return FilterOutput::MatchingLoopGeneralizedTerms(graph.show_nth_matching_loop(n, parser)),
             Filter::ShowMatchingLoopSubgraph => graph.show_matching_loop_subgraph(),
+            Filter::IgnoreEqualityNodes => graph.hide_equality_nodes(),
         }
         FilterOutput::None
     }
@@ -197,6 +200,10 @@ impl Component for GraphFilters {
             let max_depth = self.max_depth;
             Callback::from(move |_| callback.emit(vec![Filter::MaxDepth(max_depth)]))
         };
+        let ignore_equality_nodes = {
+            let callback = ctx.props().add_filters.clone();
+            Callback::from(move |_| callback.emit(vec![Filter::IgnoreEqualityNodes]))
+        };
         html! {
             <div>
                 <h2>{"Add (optional) filters:"}</h2>
@@ -235,6 +242,10 @@ impl Component for GraphFilters {
                         set_value={ctx.link().callback(Msg::SetMaxDepth)}
                     />
                     <button onclick={add_max_depth_filter}>{"Add"}</button>
+                </div>
+                <div>
+                    <label for="equality_button">{"Ignore equality nodes"}</label>
+                    <button onclick={ignore_equality_nodes} id="equality_button">{"Add"}</button>
                 </div>
                 {if !self.selected_nodes.is_empty() {
                     html! {

--- a/axiom-profiler-GUI/src/results/filters/graph_filters.rs
+++ b/axiom-profiler-GUI/src/results/filters/graph_filters.rs
@@ -25,6 +25,7 @@ pub enum Filter {
     // SelectNthMatchingLoop(usize),
     ShowMatchingLoopSubgraph,
     IgnoreEqualityNodes,
+    PruneEqualityNodes,
 }
 
 impl Display for Filter {
@@ -76,7 +77,8 @@ impl Display for Filter {
             Self::ShowMatchingLoopSubgraph => {
                 write!(f, "Showing all potential matching loops")
             }
-            Self::IgnoreEqualityNodes => write!(f, "Hiding all equality nodes")
+            Self::IgnoreEqualityNodes => write!(f, "Hiding all equality nodes"),
+            Self::PruneEqualityNodes => write!(f, "Hiding all equality nodes without visible ancestor or descendant that is an instantiation node"),
         }
     }
 }
@@ -104,6 +106,7 @@ impl Filter {
             // Filter::SelectNthMatchingLoop(n) => return FilterOutput::MatchingLoopGeneralizedTerms(graph.show_nth_matching_loop(n, parser)),
             Filter::ShowMatchingLoopSubgraph => graph.show_matching_loop_subgraph(),
             Filter::IgnoreEqualityNodes => graph.hide_equality_nodes(),
+            Filter::PruneEqualityNodes => graph.prune_equality_nodes(),
         }
         FilterOutput::None
     }
@@ -204,6 +207,10 @@ impl Component for GraphFilters {
             let callback = ctx.props().add_filters.clone();
             Callback::from(move |_| callback.emit(vec![Filter::IgnoreEqualityNodes]))
         };
+        let prune_equalities = {
+            let callback = ctx.props().add_filters.clone();
+            Callback::from(move |_| callback.emit(vec![Filter::PruneEqualityNodes]))
+        };
         html! {
             <div>
                 <h2>{"Add (optional) filters:"}</h2>
@@ -244,8 +251,12 @@ impl Component for GraphFilters {
                     <button onclick={add_max_depth_filter}>{"Add"}</button>
                 </div>
                 <div>
-                    <label for="equality_button">{"Ignore equality nodes"}</label>
-                    <button onclick={ignore_equality_nodes} id="equality_button">{"Add"}</button>
+                    <label for="hide_equalities">{"Ignore equality nodes"}</label>
+                    <button onclick={ignore_equality_nodes} id="hide_equalities">{"Add"}</button>
+                </div>
+                <div>
+                    <label for="prune_equalities">{"Prune equality nodes"}</label>
+                    <button onclick={prune_equalities} id="prune_equalities">{"Add"}</button>
                 </div>
                 {if !self.selected_nodes.is_empty() {
                     html! {

--- a/axiom-profiler-GUI/src/results/filters/graph_filters.rs
+++ b/axiom-profiler-GUI/src/results/filters/graph_filters.rs
@@ -4,7 +4,7 @@ use gloo::console::log;
 use petgraph::{stable_graph::NodeIndex, Direction};
 use smt_log_parser::{
     items::QuantIdx,
-    parsers::z3::inst_graph::{InstGraph, InstInfo, NodeData}, Z3Parser,
+    parsers::z3::inst_graph::{InstGraph, InstInfo, InstNode}, Z3Parser,
 };
 use std::fmt::Display;
 use yew::prelude::*;
@@ -22,7 +22,7 @@ pub enum Filter {
     VisitSubTreeWithRoot(NodeIndex, bool),
     MaxDepth(usize),
     ShowLongestPath(NodeIndex),
-    SelectNthMatchingLoop(usize),
+    // SelectNthMatchingLoop(usize),
     ShowMatchingLoopSubgraph,
 }
 
@@ -63,15 +63,15 @@ impl Display for Filter {
             Self::ShowLongestPath(node) => {
                 write!(f, "Showing longest path through node {}", node.index())
             }
-            Self::SelectNthMatchingLoop(n) => {
-                let ordinal = match n {
-                    0 => "".to_string(),
-                    1 => "2nd".to_string(),
-                    2 => "3rd".to_string(),
-                    n => (n+1).to_string() + "th",
-                };
-                write!(f, "Showing {} longest matching loop", ordinal)
-            }
+            // Self::SelectNthMatchingLoop(n) => {
+            //     let ordinal = match n {
+            //         0 => "".to_string(),
+            //         1 => "2nd".to_string(),
+            //         2 => "3rd".to_string(),
+            //         n => (n+1).to_string() + "th",
+            //     };
+            //     write!(f, "Showing {} longest matching loop", ordinal)
+            // }
             Self::ShowMatchingLoopSubgraph => {
                 write!(f, "Showing all potential matching loops")
             }
@@ -88,18 +88,18 @@ pub enum FilterOutput {
 impl Filter {
     pub fn apply(self: Filter, graph: &mut InstGraph, parser: &mut Z3Parser) -> FilterOutput {
         match self {
-            Filter::MaxNodeIdx(max) => graph.retain_nodes(|node: &NodeData| node.orig_graph_idx.index() <= max),
-            Filter::IgnoreTheorySolving => graph.retain_nodes(|node: &NodeData| !node.is_theory_inst),
-            Filter::IgnoreQuantifier(qidx) => graph.retain_nodes(|node: &NodeData| node.mkind.quant_idx() != qidx),
-            Filter::IgnoreAllButQuantifier(qidx) => graph.retain_nodes(|node: &NodeData| node.mkind.quant_idx() == qidx),
+            Filter::MaxNodeIdx(max) => graph.retain_nodes(|node: &InstNode| node.orig_graph_idx.index() <= max),
+            Filter::IgnoreTheorySolving => graph.retain_nodes(|node: &InstNode| !node.is_theory_inst),
+            Filter::IgnoreQuantifier(qidx) => graph.retain_nodes(|node: &InstNode| node.mkind.quant_idx() != qidx),
+            Filter::IgnoreAllButQuantifier(qidx) => graph.retain_nodes(|node: &InstNode| node.mkind.quant_idx() == qidx),
             Filter::MaxInsts(n) => graph.keep_n_most_costly(n),
             Filter::MaxBranching(n) => graph.keep_n_most_branching(n),
             Filter::ShowNeighbours(nidx, direction) => graph.show_neighbours(nidx, direction),
             Filter::VisitSubTreeWithRoot(nidx, retain) => graph.visit_descendants(nidx, retain),
             Filter::VisitSourceTree(nidx, retain) => graph.visit_ancestors(nidx, retain),
-            Filter::MaxDepth(depth) => graph.retain_nodes(|node: &NodeData| node.min_depth.unwrap() <= depth),
+            Filter::MaxDepth(depth) => graph.retain_nodes(|node: &InstNode| node.min_depth.unwrap() <= depth),
             Filter::ShowLongestPath(nidx) => return FilterOutput::LongestPath(graph.show_longest_path_through(nidx)),
-            Filter::SelectNthMatchingLoop(n) => return FilterOutput::MatchingLoopGeneralizedTerms(graph.show_nth_matching_loop(n, parser)),
+            // Filter::SelectNthMatchingLoop(n) => return FilterOutput::MatchingLoopGeneralizedTerms(graph.show_nth_matching_loop(n, parser)),
             Filter::ShowMatchingLoopSubgraph => graph.show_matching_loop_subgraph(),
         }
         FilterOutput::None

--- a/axiom-profiler-GUI/src/results/filters/graph_filters.rs
+++ b/axiom-profiler-GUI/src/results/filters/graph_filters.rs
@@ -4,7 +4,7 @@ use gloo::console::log;
 use petgraph::{stable_graph::NodeIndex, Direction};
 use smt_log_parser::{
     items::QuantIdx,
-    parsers::z3::inst_graph::{InstGraph, InstInfo, InstNode}, Z3Parser,
+    parsers::z3::inst_graph::{InstGraph, InstInfo, InstNode, NodeInfo}, Z3Parser,
 };
 use std::fmt::Display;
 use yew::prelude::*;
@@ -111,8 +111,8 @@ pub struct GraphFilters {
     max_instantiations: usize,
     max_branching: usize,
     max_depth: usize,
-    selected_insts: Vec<InstInfo>,
-    _selected_insts_listener: ContextHandle<Vec<InstInfo>>,
+    selected_nodes: Vec<NodeInfo>,
+    _selected_nodes_listener: ContextHandle<Vec<NodeInfo>>,
 }
 
 #[derive(Properties, PartialEq)]
@@ -125,7 +125,7 @@ pub enum Msg {
     SetMaxInsts(usize),
     SetMaxBranching(usize),
     SetMaxDepth(usize),
-    SelectedInstsUpdated(Vec<InstInfo>),
+    SelectedInstsUpdated(Vec<NodeInfo>),
 }
 
 impl Component for GraphFilters {
@@ -150,8 +150,8 @@ impl Component for GraphFilters {
                 self.max_depth = to;
                 true
             }
-            Msg::SelectedInstsUpdated(selected_insts) => {
-                self.selected_insts = selected_insts;
+            Msg::SelectedInstsUpdated(selected_nodes) => {
+                self.selected_nodes = selected_nodes;
                 true
             }
         }
@@ -159,7 +159,7 @@ impl Component for GraphFilters {
 
     fn create(ctx: &Context<Self>) -> Self {
         log!("Creating GraphFilters component");
-        let (selected_insts, _selected_insts_listener) = ctx
+        let (selected_nodes, _selected_nodes_listener) = ctx
             .link()
             .context(ctx.link().callback(Msg::SelectedInstsUpdated))
             .expect("No context provided");
@@ -168,8 +168,8 @@ impl Component for GraphFilters {
             max_instantiations: DEFAULT_NODE_COUNT,
             max_branching: usize::MAX,
             max_depth: usize::MAX,
-            selected_insts,
-            _selected_insts_listener,
+            selected_nodes,
+            _selected_nodes_listener,
         }
     }
     fn view(&self, ctx: &Context<Self>) -> Html {
@@ -236,9 +236,9 @@ impl Component for GraphFilters {
                     />
                     <button onclick={add_max_depth_filter}>{"Add"}</button>
                 </div>
-                {if !self.selected_insts.is_empty() {
+                {if !self.selected_nodes.is_empty() {
                     html! {
-                        <NodeActions selected_nodes={self.selected_insts.clone()} action={ctx.props().add_filters.clone()} />
+                        <NodeActions selected_nodes={self.selected_nodes.clone()} action={ctx.props().add_filters.clone()} />
                     }
                 } else {
                     html! {}

--- a/axiom-profiler-GUI/src/results/filters/node_actions.rs
+++ b/axiom-profiler-GUI/src/results/filters/node_actions.rs
@@ -1,18 +1,18 @@
 use petgraph::Direction::{Incoming, Outgoing};
-use smt_log_parser::parsers::z3::inst_graph::InstInfo;
+use smt_log_parser::parsers::z3::inst_graph::NodeInfo;
 use yew::prelude::*;
 
 use super::graph_filters::Filter;
 
 #[derive(Properties, PartialEq)]
 pub struct NodeActionsProps {
-    pub selected_nodes: Vec<InstInfo>,
+    pub selected_nodes: Vec<NodeInfo>,
     pub action: Callback<Vec<Filter>>,
 }
 
 #[function_component(NodeActions)]
 pub fn node_actions(props: &NodeActionsProps) -> Html {
-    let callback_from = |filter_for_inst: Box<dyn Fn(&InstInfo) -> Filter>| {
+    let callback_from = |filter_for_inst: Box<dyn Fn(&NodeInfo) -> Filter>| {
         let callback = props.action.clone();
         let selected_insts = props.selected_nodes.clone();
         Callback::from(move |_| {
@@ -20,32 +20,40 @@ pub fn node_actions(props: &NodeActionsProps) -> Html {
             callback.emit(filters);
         })
     };
-    let show_subtree = callback_from(Box::new(|inst: &InstInfo| {
-        Filter::VisitSubTreeWithRoot(inst.node_index, true)
+    let show_subtree = callback_from(Box::new(|inst: &NodeInfo| {
+        Filter::VisitSubTreeWithRoot(inst.node_index(), true)
     }));
-    let hide_subtree = callback_from(Box::new(|inst: &InstInfo| {
-        Filter::VisitSubTreeWithRoot(inst.node_index, false)
+    let hide_subtree = callback_from(Box::new(|inst: &NodeInfo| {
+        Filter::VisitSubTreeWithRoot(inst.node_index(), false)
     }));
-    let show_children = callback_from(Box::new(|inst: &InstInfo| {
-        Filter::ShowNeighbours(inst.node_index, Outgoing)
+    let show_children = callback_from(Box::new(|inst: &NodeInfo| {
+        Filter::ShowNeighbours(inst.node_index(), Outgoing)
     }));
-    let show_parents = callback_from(Box::new(|inst: &InstInfo| {
-        Filter::ShowNeighbours(inst.node_index, Incoming)
+    let show_parents = callback_from(Box::new(|inst: &NodeInfo| {
+        Filter::ShowNeighbours(inst.node_index(), Incoming)
     }));
-    let show_source_tree = callback_from(Box::new(|inst: &InstInfo| {
-        Filter::VisitSourceTree(inst.node_index, true)
+    let show_source_tree = callback_from(Box::new(|inst: &NodeInfo| {
+        Filter::VisitSourceTree(inst.node_index(), true)
     }));
-    let hide_source_tree = callback_from(Box::new(|inst: &InstInfo| {
-        Filter::VisitSourceTree(inst.node_index, false)
+    let hide_source_tree = callback_from(Box::new(|inst: &NodeInfo| {
+        Filter::VisitSourceTree(inst.node_index(), false)
     }));
-    let ignore_quantifier = callback_from(Box::new(|inst: &InstInfo| {
-        Filter::IgnoreQuantifier(inst.mkind.quant_idx())
+    let ignore_quantifier = callback_from(Box::new(|inst: &NodeInfo| {
+            match inst.mkind() {
+                Some(mkind) => Filter::IgnoreQuantifier(mkind.quant_idx()),
+                None => Filter::IgnoreQuantifier(None),
+            }
+        }
+    ));
+    let ignore_all_but_quantifier = callback_from(Box::new(|inst: &NodeInfo| {
+        // Filter::IgnoreAllButQuantifier(inst.mkind.quant_idx())
+            match inst.mkind() {
+                Some(mkind) => Filter::IgnoreAllButQuantifier(mkind.quant_idx()),
+                None => Filter::IgnoreAllButQuantifier(None),
+            }
     }));
-    let ignore_all_but_quantifier = callback_from(Box::new(|inst: &InstInfo| {
-        Filter::IgnoreAllButQuantifier(inst.mkind.quant_idx())
-    }));
-    let show_longest_path = callback_from(Box::new(|inst: &InstInfo| {
-        Filter::ShowLongestPath(inst.node_index)
+    let show_longest_path = callback_from(Box::new(|inst: &NodeInfo| {
+        Filter::ShowLongestPath(inst.node_index())
     }));
     html! {
     <>

--- a/axiom-profiler-GUI/src/results/graph/svg_graph.rs
+++ b/axiom-profiler-GUI/src/results/graph/svg_graph.rs
@@ -78,7 +78,7 @@ pub fn graph(props: &GraphProps) -> Html {
                         let callback = background_callback.clone();
                         let div = div.clone();
                         let closure: Closure<dyn Fn(Event)> = Closure::new(move |_: Event| {
-                            let nodes = div.get_elements_by_class_name("node");
+                            let nodes = div.get_elements_by_class_name("node inst");
                             for i in 0..nodes.length() {
                                 let node = nodes.item(i).unwrap();
                                 let ellipse = node
@@ -109,7 +109,7 @@ pub fn graph(props: &GraphProps) -> Html {
                         vec![]
                     };
                 // construct event_listeners that emit node indices (contained in title tags)
-                let descendant_nodes = div.get_elements_by_class_name("node");
+                let descendant_nodes = div.get_elements_by_class_name("node inst");
                 let node_closures: Vec<Closure<dyn Fn(Event)>> = (0..descendant_nodes.length())
                     .map(|i| {
                         // extract node_index from node to construct callback that emits it
@@ -248,7 +248,7 @@ pub fn graph(props: &GraphProps) -> Html {
                     let div = div_ref
                         .cast::<HtmlElement>()
                         .expect("div_ref not attached to div element");
-                    let nodes = div.get_elements_by_class_name("node");
+                    let nodes = div.get_elements_by_class_name("node inst");
                     for i in 0..nodes.length() {
                         let node = nodes.item(i).unwrap();
                         let node_index = NodeIndex::new(
@@ -278,7 +278,7 @@ pub fn graph(props: &GraphProps) -> Html {
         let div_ref = div_ref.clone();
         Callback::from(move |_| {
             if let Some(div_el) = div_ref.cast::<HtmlElement>() {
-                let nodes = div_el.get_elements_by_class_name("node");
+                let nodes = div_el.get_elements_by_class_name("node inst");
                 let edges = div_el.get_elements_by_class_name("edge direct");
                 for i in 0..nodes.length() {
                     let node = nodes.item(i).unwrap();

--- a/axiom-profiler-GUI/src/results/graph/svg_graph.rs
+++ b/axiom-profiler-GUI/src/results/graph/svg_graph.rs
@@ -5,7 +5,8 @@ use web_sys::{Event, HtmlElement, SvgsvgElement};
 use yew::prelude::*;
 use yew::{function_component, html, use_node_ref, Html};
 
-const NODE_SHAPE: &str = "polygon";
+const INST_NODE_SHAPE: &str = "polygon";
+const EQ_NODE_SHAPE: &str = "ellipse";
 
 #[derive(Properties, PartialEq, Default)]
 pub struct GraphProps {
@@ -78,13 +79,16 @@ pub fn graph(props: &GraphProps) -> Html {
                         let callback = background_callback.clone();
                         let div = div.clone();
                         let closure: Closure<dyn Fn(Event)> = Closure::new(move |_: Event| {
-                            let nodes = div.get_elements_by_class_name("node inst");
+                            let nodes = div.get_elements_by_class_name("node");
                             for i in 0..nodes.length() {
                                 let node = nodes.item(i).unwrap();
-                                let ellipse = node
-                                    .query_selector(NODE_SHAPE)
-                                    .expect("Failed to select ellipse")
-                                    .unwrap();
+                                let ellipse = if let Some(el) = node
+                                    .query_selector(INST_NODE_SHAPE)
+                                    .expect("Failed to select ellipse") {
+                                        el
+                                    } else {
+                                        node.query_selector(EQ_NODE_SHAPE).expect("Failed to select ellipse").unwrap()
+                                    };
                                 let _ = ellipse.set_attribute("stroke-width", "1");
                             }
                             let edges = div.get_elements_by_class_name("edge direct");
@@ -109,15 +113,18 @@ pub fn graph(props: &GraphProps) -> Html {
                         vec![]
                     };
                 // construct event_listeners that emit node indices (contained in title tags)
-                let descendant_nodes = div.get_elements_by_class_name("node inst");
+                let descendant_nodes = div.get_elements_by_class_name("node");
                 let node_closures: Vec<Closure<dyn Fn(Event)>> = (0..descendant_nodes.length())
                     .map(|i| {
                         // extract node_index from node to construct callback that emits it
                         let node = descendant_nodes.item(i).unwrap();
-                        let ellipse = node
-                            .query_selector(NODE_SHAPE)
-                            .expect("Failed to select title element")
-                            .unwrap();
+                        let ellipse = if let Some(el) = node
+                            .query_selector(INST_NODE_SHAPE)
+                            .expect("Failed to select ellipse") {
+                                el
+                            } else {
+                                node.query_selector(EQ_NODE_SHAPE).expect("Failed to select ellipse").unwrap()
+                            };
                         let node_index = node
                             .id()
                             .strip_prefix("node")
@@ -248,7 +255,7 @@ pub fn graph(props: &GraphProps) -> Html {
                     let div = div_ref
                         .cast::<HtmlElement>()
                         .expect("div_ref not attached to div element");
-                    let nodes = div.get_elements_by_class_name("node inst");
+                    let nodes = div.get_elements_by_class_name("node");
                     for i in 0..nodes.length() {
                         let node = nodes.item(i).unwrap();
                         let node_index = NodeIndex::new(
@@ -258,10 +265,13 @@ pub fn graph(props: &GraphProps) -> Html {
                                 .parse::<usize>()
                                 .unwrap(),
                         );
-                        let ellipse = node
-                            .query_selector(NODE_SHAPE)
-                            .expect("Failed to select ellipse")
-                            .unwrap();
+                        let ellipse = if let Some(el) = node
+                            .query_selector(INST_NODE_SHAPE)
+                            .expect("Failed to select ellipse") {
+                                el
+                            } else {
+                                node.query_selector(EQ_NODE_SHAPE).expect("Failed to select ellipse").unwrap()
+                            };
                         if selected_nodes.contains(&node_index) {
                             let _ = ellipse.set_attribute("stroke-width", "3");
                         } else {
@@ -278,14 +288,17 @@ pub fn graph(props: &GraphProps) -> Html {
         let div_ref = div_ref.clone();
         Callback::from(move |_| {
             if let Some(div_el) = div_ref.cast::<HtmlElement>() {
-                let nodes = div_el.get_elements_by_class_name("node inst");
+                let nodes = div_el.get_elements_by_class_name("node");
                 let edges = div_el.get_elements_by_class_name("edge direct");
                 for i in 0..nodes.length() {
                     let node = nodes.item(i).unwrap();
-                    let ellipse = node
-                        .query_selector(NODE_SHAPE)
-                        .expect("Failed to select ellipse")
-                        .unwrap();
+                    let ellipse = if let Some(el) = node
+                        .query_selector(INST_NODE_SHAPE)
+                        .expect("Failed to select ellipse") {
+                            el
+                        } else {
+                            node.query_selector(EQ_NODE_SHAPE).expect("Failed to select ellipse").unwrap()
+                        };
                     let _ = ellipse.set_attribute("stroke-width", "1");
                 }
                 for i in 0..edges.length() {

--- a/axiom-profiler-GUI/src/results/graph_info.rs
+++ b/axiom-profiler-GUI/src/results/graph_info.rs
@@ -368,11 +368,11 @@ fn selected_edges_info(
                         <h4>{"Blame term: "}</h4><p>{selected_edge.blame_term.clone()}</p>
                         </div>
                     },
-                    BlameKind::Equality { .. } => html! {
-                        <div>
-                        <h4>{"Equality: "}</h4><p>{selected_edge.blame_term.clone()}</p>
-                        </div>
-                    },
+                    // BlameKind::Equality { .. } => html! {
+                    //     <div>
+                    //     <h4>{"Equality: "}</h4><p>{selected_edge.blame_term.clone()}</p>
+                    //     </div>
+                    // },
                     _ => html! {}
                 }}
             </details>

--- a/axiom-profiler-GUI/src/results/graph_info.rs
+++ b/axiom-profiler-GUI/src/results/graph_info.rs
@@ -3,7 +3,7 @@ use gloo::console::log;
 use indexmap::map::IndexMap;
 use material_yew::WeakComponentLink;
 use petgraph::graph::{EdgeIndex, NodeIndex};
-use smt_log_parser::parsers::z3::inst_graph::EdgeType;
+use smt_log_parser::parsers::z3::inst_graph::{EdgeType, NodeInfo};
 use smt_log_parser::{
     items::BlameKind,
     parsers::z3::{
@@ -19,7 +19,7 @@ use super::graph::graph_container::GraphContainer;
 
 pub struct GraphInfo {
     is_expanded_node: IndexMap<NodeIndex, bool>,
-    selected_nodes: IndexMap<NodeIndex, InstInfo>,
+    selected_nodes: IndexMap<NodeIndex, NodeInfo>,
     selected_nodes_ref: NodeRef,
     is_expanded_edge: IndexMap<EdgeIndex, bool>,
     selected_edges: IndexMap<EdgeIndex, EdgeInfo>,
@@ -42,11 +42,11 @@ pub enum Msg {
 #[derive(Properties, PartialEq)]
 pub struct GraphInfoProps {
     pub weak_link: WeakComponentLink<GraphInfo>,
-    pub node_info: Callback<(NodeIndex, bool, RcParser), InstInfo>,
+    pub node_info: Callback<(NodeIndex, bool, RcParser), NodeInfo>,
     pub edge_info: Callback<(EdgeIndex, bool, RcParser), EdgeInfo>,
     pub parser: RcParser,
     pub svg_text: AttrValue,
-    pub update_selected_nodes: Callback<Vec<InstInfo>>,
+    pub update_selected_nodes: Callback<Vec<NodeInfo>>,
 }
 
 impl Component for GraphInfo {
@@ -79,12 +79,12 @@ impl Component for GraphInfo {
                     self.selected_nodes.shift_remove(&node_index);
                     self.is_expanded_node.remove(&node_index);
                 } else {
-                    let inst_info = ctx.props().node_info.emit((
+                    let node_info = ctx.props().node_info.emit((
                         node_index,
                         self.ignore_term_ids,
                         ctx.props().parser.clone(),
                     ));
-                    self.selected_nodes.insert(node_index, inst_info);
+                    self.selected_nodes.insert(node_index, node_info);
                     // When adding a single new node,
                     // close all
                     for val in self.is_expanded_node.values_mut() {
@@ -97,7 +97,7 @@ impl Component for GraphInfo {
                     self.selected_nodes
                         .values()
                         .cloned()
-                        .collect::<Vec<InstInfo>>(),
+                        .collect::<Vec<NodeInfo>>(),
                 );
                 true
             }
@@ -143,7 +143,7 @@ impl Component for GraphInfo {
                     self.selected_nodes
                         .values()
                         .cloned()
-                        .collect::<Vec<InstInfo>>(),
+                        .collect::<Vec<NodeInfo>>(),
                 );
                 true
             }
@@ -163,14 +163,14 @@ impl Component for GraphInfo {
                     self.selected_nodes
                         .values()
                         .cloned()
-                        .collect::<Vec<InstInfo>>(),
+                        .collect::<Vec<NodeInfo>>(),
                 );
                 true
             }
             Msg::ToggleIgnoreTermIds => {
                 self.ignore_term_ids = !self.ignore_term_ids;
                 for node in self.selected_nodes.values_mut() {
-                    let node_idx = node.node_index;
+                    let node_idx = node.node_index();
                     let updated_node = ctx.props().node_info.emit((
                         node_idx,
                         self.ignore_term_ids,
@@ -262,7 +262,7 @@ impl Component for GraphInfo {
                 </div>
                 <h2>{"Information about selected nodes:"}</h2>
                 <div ref={self.selected_nodes_ref.clone()}>
-                    <SelectedNodesInfo selected_nodes={self.selected_nodes.values().cloned().collect::<Vec<InstInfo>>()} on_click={on_node_click} />
+                    <SelectedNodesInfo selected_nodes={self.selected_nodes.values().cloned().collect::<Vec<NodeInfo>>()} on_click={on_node_click} />
                 </div>
                 <h2>{"Information about selected dependencies:"}</h2>
                 <div ref={self.selected_edges_ref.clone()}>
@@ -281,7 +281,7 @@ impl Component for GraphInfo {
 
 #[derive(Properties, PartialEq)]
 struct SelectedNodesInfoProps {
-    selected_nodes: Vec<InstInfo>,
+    selected_nodes: Vec<NodeInfo>,
     on_click: Callback<NodeIndex>,
 }
 
@@ -294,36 +294,45 @@ fn selected_nodes_info(
 ) -> Html {
     selected_nodes
         .iter()
-        .map(|selected_inst| {
-            let get_ul = |label: &str, items: &Vec<String>| html! {
-                <>
-                    <h4>{label}</h4>
-                    <ul>{for items.iter().map(|item| html!{<li>{item}</li>})}</ul>
-                </>
-            };
-            let on_select = {
-                let on_click = on_click.clone();
-                let selected_inst = selected_inst.clone();
-                Callback::from(move |_| {
-                    on_click.emit(selected_inst.node_index)
-                })
-            };
-            let z3_gen = selected_inst.z3_gen.map(|gen| format!(", Z3 generation {gen}")).unwrap_or_default();
-            html! {
-            <details id={format!("{}", selected_inst.node_index.index())} onclick={on_select}>
-                <summary>{format!("Node {}", selected_inst.node_index.index())}</summary>
-                <ul>
-                    <li><h4>{"Instantiation number: "}</h4><p>{format!("{}", selected_inst.inst_idx)}</p></li>
-                    <li><h4>{"Cost: "}</h4><p>{"Calculated "}{selected_inst.cost}{z3_gen}</p></li>
-                    <li><h4>{"Instantiated formula: "}</h4><p>{&selected_inst.formula}</p></li>
-                    <li>{get_ul("Blamed terms: ", &selected_inst.blamed_terms)}</li>
-                    <li>{get_ul("Bound terms: ", &selected_inst.bound_terms)}</li>
-                    <li>{get_ul("Yield terms: ", &selected_inst.yields_terms)}</li>
-                    <li>{get_ul("Equality explanations: ", &selected_inst.equality_expls)}</li>
-                    <li><h4>{"Resulting term: "}</h4><p>{if let Some(ref val) = selected_inst.resulting_term {val.to_string()} else { String::new() }}</p></li>
-                </ul>
-            </details>
-        }})
+        .map(|selected_node| match selected_node {
+            NodeInfo::Inst(selected_inst) => {
+                    let get_ul = |label: &str, items: &Vec<String>| html! {
+                    <>
+                        <h4>{label}</h4>
+                        <ul>{for items.iter().map(|item| html!{<li>{item}</li>})}</ul>
+                    </>
+                };
+                let on_select = {
+                    let on_click = on_click.clone();
+                    let selected_inst = selected_inst.clone();
+                    Callback::from(move |_| {
+                        on_click.emit(selected_inst.node_index)
+                    })
+                };
+                let z3_gen = selected_inst.z3_gen.map(|gen| format!(", Z3 generation {gen}")).unwrap_or_default();
+                html! {
+                <details id={format!("{}", selected_inst.node_index.index())} onclick={on_select}>
+                    <summary>{format!("Node {}", selected_inst.node_index.index())}</summary>
+                    <ul>
+                        <li><h4>{"Instantiation number: "}</h4><p>{format!("{}", selected_inst.inst_idx)}</p></li>
+                        <li><h4>{"Cost: "}</h4><p>{"Calculated "}{selected_inst.cost}{z3_gen}</p></li>
+                        <li><h4>{"Instantiated formula: "}</h4><p>{&selected_inst.formula}</p></li>
+                        <li>{get_ul("Blamed terms: ", &selected_inst.blamed_terms)}</li>
+                        <li>{get_ul("Bound terms: ", &selected_inst.bound_terms)}</li>
+                        <li>{get_ul("Yield terms: ", &selected_inst.yields_terms)}</li>
+                        <li>{get_ul("Equality explanations: ", &selected_inst.equality_expls)}</li>
+                        <li><h4>{"Resulting term: "}</h4><p>{if let Some(ref val) = selected_inst.resulting_term {val.to_string()} else { String::new() }}</p></li>
+                    </ul>
+                </details>
+            }}
+            NodeInfo::Equality(selected_eq) => {
+                html! {
+                    <>
+                    <h4>{"Equality: "}</h4><p>{selected_eq.equality.clone()}</p>
+                    </>
+                }
+            }
+        })
         .collect()
 }
 

--- a/axiom-profiler-GUI/src/results/svg_result.rs
+++ b/axiom-profiler-GUI/src/results/svg_result.rs
@@ -19,7 +19,7 @@ use smt_log_parser::{
     items::{BlameKind, MatchKind},
     parsers::{
         z3::{
-            inst_graph::{EdgeInfo, EdgeType, InstGraph, InstInfo, Node, VisibleGraphInfo},
+            inst_graph::{EdgeInfo, EdgeType, InstGraph, InstInfo, Node, NodeInfo, VisibleGraphInfo},
             z3parser::Z3Parser,
         },
         LogParser,
@@ -42,7 +42,7 @@ pub enum Msg {
     ResetGraph,
     GetUserPermission,
     WorkerOutput(super::worker::WorkerOutput),
-    UpdateSelectedNodes(Vec<InstInfo>),
+    UpdateSelectedNodes(Vec<NodeInfo>),
     SearchMatchingLoops,
     // SelectNthMatchingLoop(usize),
     ShowMatchingLoopSubgraph,
@@ -74,9 +74,9 @@ pub struct SVGResult {
     graph_dim: GraphDimensions,
     worker: Option<Box<dyn yew_agent::Bridge<Worker>>>,
     async_graph_and_filter_chain: bool,
-    get_node_info: Callback<(NodeIndex, bool, RcParser), InstInfo>,
+    get_node_info: Callback<(NodeIndex, bool, RcParser), NodeInfo>,
     get_edge_info: Callback<(EdgeIndex, bool, RcParser), EdgeInfo>,
-    selected_insts: Vec<InstInfo>,
+    selected_nodes: Vec<NodeInfo>,
     searched_matching_loops: bool,
     matching_loop_count: usize,
 }
@@ -123,7 +123,7 @@ impl Component for SVGResult {
             async_graph_and_filter_chain: false,
             get_node_info,
             get_edge_info,
-            selected_insts: Vec::new(),
+            selected_nodes: Vec::new(),
             searched_matching_loops: false,
             matching_loop_count: 0,
         }
@@ -249,10 +249,9 @@ impl Component for SVGResult {
                             &|_, (_, node_data)| {
                                 match node_data {
                                     Node::Inst(inst) => {
-                                        format!("id=node{} label=\"{}\" class={} style=\"{}\" shape={} fillcolor=\"{}\" fontcolor=black gradientangle=90",
+                                        format!("id=node{} label=\"{}\" style=\"{}\" shape={} fillcolor=\"{}\" fontcolor=black gradientangle=90",
                                             inst.orig_graph_idx.index(),
                                             inst.orig_graph_idx.index(),
-                                            "inst",
                                             if inst.mkind.is_mbqi() { "filled,dashed" } else { "filled" },
                                             // match (self.inst_graph.node_has_filtered_children(node_data.orig_graph_idx), 
                                             //        self.inst_graph.node_has_filtered_parents(node_data.orig_graph_idx)) {
@@ -272,10 +271,9 @@ impl Component for SVGResult {
                                         )
                                     },
                                     Node::Equality(eq) => {
-                                        format!("id=node{} label=\"{}\" class={}",
+                                        format!("id=node{} label=\"{}\"",
                                             eq.orig_graph_idx.index(),
                                             eq.orig_graph_idx.index(),
-                                            "eq"
                                         )
                                     },
                                 }
@@ -367,7 +365,7 @@ impl Component for SVGResult {
                 }
             }
             Msg::UpdateSelectedNodes(nodes) => {
-                self.selected_insts = nodes;
+                self.selected_nodes = nodes;
                 true
             }
         }
@@ -405,14 +403,14 @@ impl Component for SVGResult {
                         // </>
                     }
                 }}
-                <ContextProvider<Vec<InstInfo>> context={self.selected_insts.clone()}>
+                <ContextProvider<Vec<NodeInfo>> context={self.selected_nodes.clone()}>
                     <FilterChain
                         apply_filter={apply_filter.clone()}
                         reset_graph={reset_graph.clone()}
                         render_graph={render_graph.clone()}
                         weak_link={self.filter_chain_link.clone()}
                     />
-                </ContextProvider<Vec<InstInfo>>>
+                </ContextProvider<Vec<NodeInfo>>>
                 {async_graph_and_filter_chain_warning}
                 {node_and_edge_count_preview}
                 </div>

--- a/axiom-profiler-GUI/src/results/svg_result.rs
+++ b/axiom-profiler-GUI/src/results/svg_result.rs
@@ -271,7 +271,7 @@ impl Component for SVGResult {
                                         )
                                     },
                                     Node::Equality(eq) => {
-                                        format!("id=node{} label=\"{}\"",
+                                        format!("id=node{} label=\"{}\" style=filled fillcolor=white",
                                             eq.orig_graph_idx.index(),
                                             eq.orig_graph_idx.index(),
                                         )

--- a/axiom-profiler-GUI/src/results/svg_result.rs
+++ b/axiom-profiler-GUI/src/results/svg_result.rs
@@ -44,7 +44,7 @@ pub enum Msg {
     WorkerOutput(super::worker::WorkerOutput),
     UpdateSelectedNodes(Vec<InstInfo>),
     SearchMatchingLoops,
-    SelectNthMatchingLoop(usize),
+    // SelectNthMatchingLoop(usize),
     ShowMatchingLoopSubgraph,
 }
 
@@ -157,17 +157,17 @@ impl Component for SVGResult {
             Msg::SearchMatchingLoops => {
                 self.matching_loop_count = self.inst_graph.search_matching_loops();
                 self.searched_matching_loops = true;
-                ctx.link().send_message(Msg::SelectNthMatchingLoop(0));
+                // ctx.link().send_message(Msg::SelectNthMatchingLoop(0));
                 true
             }
-            Msg::SelectNthMatchingLoop(n) => {
-                self.filter_chain_link
-                    .borrow()
-                    .clone()
-                    .unwrap()
-                    .send_message(FilterChainMsg::AddFilters(vec![Filter::SelectNthMatchingLoop(n)]));
-                false
-            }
+            // Msg::SelectNthMatchingLoop(n) => {
+            //     self.filter_chain_link
+            //         .borrow()
+            //         .clone()
+            //         .unwrap()
+            //         .send_message(FilterChainMsg::AddFilters(vec![Filter::SelectNthMatchingLoop(n)]));
+            //     false
+            // }
             Msg::ShowMatchingLoopSubgraph => {
                 self.filter_chain_link
                     .borrow()
@@ -248,9 +248,9 @@ impl Component for SVGResult {
                             ),
                             &|_, (_, node_data)| {
                                 format!("id=node{} label=\"{}\" style=\"{}\" shape={} fillcolor=\"{}\" fontcolor=black gradientangle=90",
-                                        node_data.orig_graph_idx.index(),
-                                        node_data.orig_graph_idx.index(),
-                                        if node_data.mkind.is_mbqi() { "filled,dashed" } else { "filled" },
+                                        node_data.orig_graph_idx().index(),
+                                        node_data.orig_graph_idx().index(),
+                                        if node_data.inner_inst().unwrap().mkind.is_mbqi() { "filled,dashed" } else { "filled" },
                                         // match (self.inst_graph.node_has_filtered_children(node_data.orig_graph_idx), 
                                         //        self.inst_graph.node_has_filtered_parents(node_data.orig_graph_idx)) {
                                         //     (false, false) => format!("{}", self.colour_map.get(&node_data.quant_idx, 0.7)),
@@ -258,14 +258,14 @@ impl Component for SVGResult {
                                         //     (true, false) => format!("{}:{}", self.colour_map.get(&node_data.quant_idx, 0.1), self.colour_map.get(&node_data.quant_idx, 1.0)),
                                         //     (true, true) => format!("{}", self.colour_map.get(&node_data.quant_idx, 0.3)),
                                         // },
-                                        match (self.inst_graph.node_has_filtered_children(node_data.orig_graph_idx),
-                                               self.inst_graph.node_has_filtered_parents(node_data.orig_graph_idx)) {
+                                        match (self.inst_graph.node_has_filtered_children(node_data.orig_graph_idx()),
+                                               self.inst_graph.node_has_filtered_parents(node_data.orig_graph_idx())) {
                                             (false, false) => "box",
                                             (false, true) => "house",
                                             (true, false) => "invhouse",
                                             (true, true) => "diamond",
                                         },
-                                        self.colour_map.get(&node_data.mkind, NODE_COLOUR_SATURATION),
+                                        self.colour_map.get(&node_data.inner_inst().unwrap().mkind, NODE_COLOUR_SATURATION),
                                     )
                             },
                         )
@@ -382,14 +382,14 @@ impl Component for SVGResult {
                     }
                 } else {
                     html! {
-                        <>
-                        <Indexer 
-                            label="Analyzed matching loops" 
-                            index_consumer={ctx.link().callback(Msg::SelectNthMatchingLoop)}
-                            max={self.matching_loop_count - 1}
-                        />
-                        <button onclick={ctx.link().callback(|_| Msg::ShowMatchingLoopSubgraph)}>{"Show all matching loops"}</button>
-                        </>
+                        // <>
+                        // <Indexer 
+                        //     label="Analyzed matching loops" 
+                        //     index_consumer={ctx.link().callback(Msg::SelectNthMatchingLoop)}
+                        //     max={self.matching_loop_count - 1}
+                        // />
+                        // <button onclick={ctx.link().callback(|_| Msg::ShowMatchingLoopSubgraph)}>{"Show all matching loops"}</button>
+                        // </>
                     }
                 }}
                 <ContextProvider<Vec<InstInfo>> context={self.selected_insts.clone()}>

--- a/axiom-profiler-GUI/src/results/svg_result.rs
+++ b/axiom-profiler-GUI/src/results/svg_result.rs
@@ -19,7 +19,7 @@ use smt_log_parser::{
     items::{BlameKind, MatchKind},
     parsers::{
         z3::{
-            inst_graph::{EdgeInfo, EdgeType, InstGraph, InstInfo, VisibleGraphInfo},
+            inst_graph::{EdgeInfo, EdgeType, InstGraph, InstInfo, Node, VisibleGraphInfo},
             z3parser::Z3Parser,
         },
         LogParser,
@@ -247,26 +247,39 @@ impl Component for SVGResult {
                                 }
                             ),
                             &|_, (_, node_data)| {
-                                format!("id=node{} label=\"{}\" style=\"{}\" shape={} fillcolor=\"{}\" fontcolor=black gradientangle=90",
-                                        node_data.orig_graph_idx().index(),
-                                        node_data.orig_graph_idx().index(),
-                                        if node_data.inner_inst().unwrap().mkind.is_mbqi() { "filled,dashed" } else { "filled" },
-                                        // match (self.inst_graph.node_has_filtered_children(node_data.orig_graph_idx), 
-                                        //        self.inst_graph.node_has_filtered_parents(node_data.orig_graph_idx)) {
-                                        //     (false, false) => format!("{}", self.colour_map.get(&node_data.quant_idx, 0.7)),
-                                        //     (false, true) => format!("{}:{}", self.colour_map.get(&node_data.quant_idx, 1.0), self.colour_map.get(&node_data.quant_idx, 0.1)),
-                                        //     (true, false) => format!("{}:{}", self.colour_map.get(&node_data.quant_idx, 0.1), self.colour_map.get(&node_data.quant_idx, 1.0)),
-                                        //     (true, true) => format!("{}", self.colour_map.get(&node_data.quant_idx, 0.3)),
-                                        // },
-                                        match (self.inst_graph.node_has_filtered_children(node_data.orig_graph_idx()),
-                                               self.inst_graph.node_has_filtered_parents(node_data.orig_graph_idx())) {
-                                            (false, false) => "box",
-                                            (false, true) => "house",
-                                            (true, false) => "invhouse",
-                                            (true, true) => "diamond",
-                                        },
-                                        self.colour_map.get(&node_data.inner_inst().unwrap().mkind, NODE_COLOUR_SATURATION),
-                                    )
+                                match node_data {
+                                    Node::Inst(inst) => {
+                                        format!("id=node{} label=\"{}\" class={} style=\"{}\" shape={} fillcolor=\"{}\" fontcolor=black gradientangle=90",
+                                            inst.orig_graph_idx.index(),
+                                            inst.orig_graph_idx.index(),
+                                            "inst",
+                                            if inst.mkind.is_mbqi() { "filled,dashed" } else { "filled" },
+                                            // match (self.inst_graph.node_has_filtered_children(node_data.orig_graph_idx), 
+                                            //        self.inst_graph.node_has_filtered_parents(node_data.orig_graph_idx)) {
+                                            //     (false, false) => format!("{}", self.colour_map.get(&node_data.quant_idx, 0.7)),
+                                            //     (false, true) => format!("{}:{}", self.colour_map.get(&node_data.quant_idx, 1.0), self.colour_map.get(&node_data.quant_idx, 0.1)),
+                                            //     (true, false) => format!("{}:{}", self.colour_map.get(&node_data.quant_idx, 0.1), self.colour_map.get(&node_data.quant_idx, 1.0)),
+                                            //     (true, true) => format!("{}", self.colour_map.get(&node_data.quant_idx, 0.3)),
+                                            // },
+                                            match (self.inst_graph.node_has_filtered_children(inst.orig_graph_idx),
+                                                self.inst_graph.node_has_filtered_parents(inst.orig_graph_idx)) {
+                                                (false, false) => "box",
+                                                (false, true) => "house",
+                                                (true, false) => "invhouse",
+                                                (true, true) => "diamond",
+                                            },
+                                            self.colour_map.get(&inst.mkind, NODE_COLOUR_SATURATION),
+                                        )
+                                    },
+                                    Node::Equality(eq) => {
+                                        format!("id=node{} label=\"{}\" class={}",
+                                            eq.orig_graph_idx.index(),
+                                            eq.orig_graph_idx.index(),
+                                            "eq"
+                                        )
+                                    },
+                                }
+                                
                             },
                         )
                     );

--- a/smt-log-parser/src/parsers/z3/egraph.rs
+++ b/smt-log-parser/src/parsers/z3/egraph.rs
@@ -133,7 +133,9 @@ impl EGraph {
     }
 
     pub fn blame_equalities(&self, from: ENodeIdx, to: ENodeIdx, stack: &Stack, blamed: &mut Vec<(ENodeIdx, ENodeIdx)>, can_mismatch: impl Fn() -> bool) -> Result<()> {
-        blamed.push((from, to));
+        if from != to {
+            blamed.push((from, to));
+        }
         // for eq in self.get_equalities(from, to, stack, can_mismatch)? {
         //     // TODO: figure out if this is all the blames we need.
         //     match eq {

--- a/smt-log-parser/src/parsers/z3/egraph.rs
+++ b/smt-log-parser/src/parsers/z3/egraph.rs
@@ -63,6 +63,10 @@ impl EGraph {
     }
 
     pub fn new_equality(&mut self, from: ENodeIdx, expl: EqualityExpl, stack: &Stack) -> Result<(ENodeIdx, ENodeIdx, Option<InstIdx>)> {
+        let eq_created_by = match expl {
+            EqualityExpl::Literal { eq, .. } => self.enodes[eq].created_by,
+            _ => None,
+        };
         let enode = &mut self.enodes[from];
         let to = expl.to();
         let eq = Equality {
@@ -92,7 +96,7 @@ impl EGraph {
         //         panic!();
         //     }
         // }
-        Ok((from, to, enode.created_by))
+        Ok((from, to, eq_created_by))
     }
 
     pub fn path_to_root(&self, from: ENodeIdx, stack: &Stack, depth: usize) -> Vec<ENodeIdx> {

--- a/smt-log-parser/src/parsers/z3/inst_graph.rs
+++ b/smt-log-parser/src/parsers/z3/inst_graph.rs
@@ -1028,14 +1028,14 @@ impl InstGraph {
     }
 
     fn add_eq_node(&mut self, node_data: EqualityNode) -> NodeIndex {
-        // if let Some(nx) = self.node_idx_of_eq.get(&node_data) {
-        //     *nx
-        // } else {
+        if let Some(nx) = self.node_idx_of_eq.get(&node_data) {
+            *nx
+        } else {
             let node = self.orig_graph.add_node(Node::Equality(node_data));
             self.orig_graph[node].set_orig_graph_idx_to(node);
             self.node_idx_of_eq.insert(node_data, node);
             node
-        // }
+        }
     }
 
     fn add_edge(&mut self, from: InstIdx, to: InstIdx, blame: &BlameKind) {

--- a/smt-log-parser/src/parsers/z3/inst_graph.rs
+++ b/smt-log-parser/src/parsers/z3/inst_graph.rs
@@ -393,7 +393,7 @@ impl InstGraph {
                 },
             }
         }
-        for node in new_inst_graph.node_weights_mut() {
+        for node in new_inst_graph.node_weights() {
             let orig_nx = node.orig_graph_idx();
             self.orig_graph[orig_nx].set_visibility_to(node.has_visible_ancestor() && node.has_visible_descendant());
         }

--- a/smt-log-parser/src/parsers/z3/inst_graph.rs
+++ b/smt-log-parser/src/parsers/z3/inst_graph.rs
@@ -669,7 +669,7 @@ impl InstGraph {
         let mut matching_loop_nodes_per_quant: Vec<FxHashSet<NodeIndex>> = Vec::new();
         log!(format!("Start processing quants"));
         for quant in quants {
-            log!(format!("Processing quant {}", quant));
+            // log!(format!("Processing quant {}", quant));
             self.reset_visibility_to(true);
             self.retain_nodes(|node| {
                 node.mkind
@@ -1109,7 +1109,7 @@ impl InstGraph {
     fn add_inst_node(&mut self, node_data: InstNode) {
         let inst_idx = node_data.inst_idx;
         let node = self.orig_graph.add_node(Node::Inst(node_data));
-        log!(format!("Processing inst with node index {}", node.index()));
+        // log!(format!("Processing inst with node index {}", node.index()));
         let ins_idx = self.node_of_inst_idx.push_and_get_key(node);
         assert_eq!(ins_idx, inst_idx);
         // store original node-index in each node
@@ -1414,16 +1414,18 @@ mod equalities {
             if let (Some(from), Some(to)) = (self.node_idx_of_weight.get(from), self.node_idx_of_weight.get(to)) {
                 let shortest_path_lengths = dijkstra(&self.graph, *from, Some(*to), |_| 1);
                 let mut curr = *to;
-                let mut curr_dist = *shortest_path_lengths.get(&curr).unwrap();
-                while let Some(ref node) = self.graph
-                .neighbors(curr)
-                .filter(|nx| if let Some(&dist) = shortest_path_lengths.get(nx) { dist == curr_dist - 1 } else { false })
-                .next() {
-                    let curr_eq = self.graph.node_weight(curr).unwrap();
-                    let node_eq = self.graph.node_weight(*node).unwrap();
-                    blamed_eqs.push((*node_eq, *curr_eq));
-                    curr = node.clone();
-                    curr_dist = curr_dist - 1;
+                if let Some(dist) = shortest_path_lengths.get(&curr) {
+                    let mut curr_dist = *dist;
+                    while let Some(ref node) = self.graph
+                    .neighbors(curr)
+                    .filter(|nx| if let Some(&dist) = shortest_path_lengths.get(nx) { dist == curr_dist - 1 } else { false })
+                    .next() {
+                        let curr_eq = self.graph.node_weight(curr).unwrap();
+                        let node_eq = self.graph.node_weight(*node).unwrap();
+                        blamed_eqs.push((*node_eq, *curr_eq));
+                        curr = node.clone();
+                        curr_dist = curr_dist - 1;
+                    }
                 }
             }
             // need to check that the blamed equality is not the same as from = to. 

--- a/smt-log-parser/src/parsers/z3/inst_graph.rs
+++ b/smt-log-parser/src/parsers/z3/inst_graph.rs
@@ -72,7 +72,7 @@ impl Hash for EqualityNode {
 
 impl PartialEq for EqualityNode {
     fn eq(&self, other: &Self) -> bool {
-        self.from == other.from && self.to == other.to
+        (self.from == other.from && self.to == other.to) || (self.from == other.to && self.to == other.from) 
     }
 }
 
@@ -91,11 +91,6 @@ impl EqualityNode {
             from: *from, 
             to: *to, 
         }
-    }
-    fn rev(&self) -> Self {
-        let from = self.from;
-        let to = self.to;
-        EqualityNode::from(&to, &from)
     }
 }
 
@@ -1095,7 +1090,6 @@ impl InstGraph {
             let nx = self.orig_graph.add_node(Node::Equality(eq));
             self.orig_graph[nx].set_orig_graph_idx_to(nx);
             self.node_idx_of_eq.insert(eq, nx);
-            self.node_idx_of_eq.insert(eq.rev(), nx);
             nx
         }
     }
@@ -1106,23 +1100,18 @@ impl InstGraph {
     }
 
     fn add_eq_edge_to_inst(&mut self, eq: EqualityNode, to: InstIdx) {
-        // let (from, to) = (self.node_of_inst_idx[from], self.node_of_inst_idx[to]);
         let to = self.node_of_inst_idx[to];
         let eq_nx = self.add_eq_node(eq);
-        // self.orig_graph.update_edge(from, eq, blame.clone());
         self.orig_graph.update_edge(eq_nx, to, BlameKind::Equality);
     }
 
     fn add_eq_edge_from_inst(&mut self, from: InstIdx, eq: EqualityNode) {
-        // let (from, to) = (self.node_of_inst_idx[from], self.node_of_inst_idx[to]);
         let from = self.node_of_inst_idx[from];
         let eq_nx = self.add_eq_node(eq);
-        // self.orig_graph.update_edge(from, eq, blame.clone());
         self.orig_graph.update_edge(from, eq_nx, BlameKind::Equality);
     }
 
     fn add_eq_edge(&mut self, from: EqualityNode, to: EqualityNode) {
-        // let from = self.node_idx_of_eq.get(&from).unwrap();
         let from_nx = self.add_eq_node(from);
         let to_nx = self.add_eq_node(to);
         self.orig_graph.update_edge(from_nx, to_nx, BlameKind::Equality);

--- a/smt-log-parser/src/parsers/z3/z3parser.rs
+++ b/smt-log-parser/src/parsers/z3/z3parser.rs
@@ -29,6 +29,7 @@ pub struct Z3Parser {
     pub(super) stack: Stack,
 
     pub strings: StringTable,
+    pub(super) cg_eqs: Vec<EqualityExpl>,
 }
 
 impl Default for Z3Parser {
@@ -43,6 +44,7 @@ impl Default for Z3Parser {
             egraph: Default::default(),
             stack: Default::default(),
             strings,
+            cg_eqs: Vec::new(),
         }
     }
 }
@@ -341,7 +343,9 @@ impl Z3LogParser for Z3Parser {
                 "cg" => {
                     let arg_eqs = self.gobble_enode_pairs(kind_dependent_info)?;
                     let to = self.parse_existing_enode(l.next().ok_or(Error::UnexpectedNewline)?)?;
-                    EqualityExpl::Congruence { from, arg_eqs, to }
+                    let eq_expl = EqualityExpl::Congruence { from, arg_eqs, to };
+                    self.cg_eqs.push(eq_expl.clone());
+                    eq_expl
                     // For each pair (#A #B), reconstruct dependent equality explanations connecting #A to #B ...
                 }
                 "th" => {

--- a/smt-log-parser/src/parsers/z3/z3parser.rs
+++ b/smt-log-parser/src/parsers/z3/z3parser.rs
@@ -339,14 +339,14 @@ impl Z3LogParser for Z3Parser {
                     Self::expect_completed(kind_dependent_info)?;
                     let to = self.parse_existing_enode(l.next().ok_or(Error::UnexpectedNewline)?)?;
                     let eq_expl = EqualityExpl::Literal { from, eq, to };
-                    self.equalities.push(eq_expl.clone());
+                    // self.equalities.push(eq_expl.clone());
                     eq_expl
                 }
                 "cg" => {
                     let arg_eqs = self.gobble_enode_pairs(kind_dependent_info)?;
                     let to = self.parse_existing_enode(l.next().ok_or(Error::UnexpectedNewline)?)?;
                     let eq_expl = EqualityExpl::Congruence { from, arg_eqs, to };
-                    self.equalities.push(eq_expl.clone());
+                    // self.equalities.push(eq_expl.clone());
                     eq_expl
                     // For each pair (#A #B), reconstruct dependent equality explanations connecting #A to #B ...
                 }
@@ -375,6 +375,7 @@ impl Z3LogParser for Z3Parser {
                 }
             }
         };
+        self.equalities.push(eq_expl.clone());
         // Return if there is unexpectedly more data
         Self::expect_completed(l)?;
 

--- a/smt-log-parser/src/parsers/z3/z3parser.rs
+++ b/smt-log-parser/src/parsers/z3/z3parser.rs
@@ -29,7 +29,7 @@ pub struct Z3Parser {
     pub(super) stack: Stack,
 
     pub strings: StringTable,
-    pub(super) cg_eqs: Vec<EqualityExpl>,
+    pub(super) equalities: Vec<EqualityExpl>,
 }
 
 impl Default for Z3Parser {
@@ -44,7 +44,7 @@ impl Default for Z3Parser {
             egraph: Default::default(),
             stack: Default::default(),
             strings,
-            cg_eqs: Vec::new(),
+            equalities: Vec::new(),
         }
     }
 }
@@ -338,13 +338,15 @@ impl Z3LogParser for Z3Parser {
                     let eq = self.parse_existing_enode(eq)?;
                     Self::expect_completed(kind_dependent_info)?;
                     let to = self.parse_existing_enode(l.next().ok_or(Error::UnexpectedNewline)?)?;
-                    EqualityExpl::Literal { from, eq, to }
+                    let eq_expl = EqualityExpl::Literal { from, eq, to };
+                    self.equalities.push(eq_expl.clone());
+                    eq_expl
                 }
                 "cg" => {
                     let arg_eqs = self.gobble_enode_pairs(kind_dependent_info)?;
                     let to = self.parse_existing_enode(l.next().ok_or(Error::UnexpectedNewline)?)?;
                     let eq_expl = EqualityExpl::Congruence { from, arg_eqs, to };
-                    self.cg_eqs.push(eq_expl.clone());
+                    self.equalities.push(eq_expl.clone());
                     eq_expl
                     // For each pair (#A #B), reconstruct dependent equality explanations connecting #A to #B ...
                 }


### PR DESCRIPTION
The basic idea is that I initially add all nodes for the equalities corresponding to `[eq-expl]` with `lit` or `cg` in the log. The code in `inst_graph.rs` should document the procedure pretty well.

Note: I've removed the functionality of detecting matching loops for now since the latest matching-loop-graph-2 branch anyways uses a completely different approach.