### PR TITLE
Disabling filters when in ML viewer mode

### DIFF
--- a/axiom-profiler-GUI/src/configuration/provider.rs
+++ b/axiom-profiler-GUI/src/configuration/provider.rs
@@ -65,7 +65,7 @@ impl ConfigurationProvider {
         self.update.update(|cfg| f(&mut cfg.parser));
     }
     pub fn reset_ml_viewer_mode(&self) {
-        self.update.update(|cfg| {cfg.persistent.ml_viewer_mode = false; true});
+        self.update.update(|cfg| {cfg.ml_viewer_mode = false; true});
     }
 }
 
@@ -73,12 +73,12 @@ impl ConfigurationProvider {
 pub struct Configuration {
     pub parser: Option<RcParser>,
     pub persistent: PersistentConfiguration,
+    pub ml_viewer_mode: bool, 
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct PersistentConfiguration {
     pub display: DisplayConfiguration,
-    pub ml_viewer_mode: bool, 
 }
 impl PersistentConfiguration {
     pub const fn default_const() -> Self {
@@ -93,7 +93,6 @@ impl PersistentConfiguration {
         };
         Self {
             display,
-            ml_viewer_mode: false,
         }
     }
 }
@@ -121,7 +120,7 @@ impl Component for ConfigurationProvider {
         if let Ok(cached) = gloo::storage::LocalStorage::get::<PersistentConfiguration>("config") {
             // log::warn!("ConfigurationProvider loaded: {cached:?}");
             config.persistent = cached;
-            config.persistent.ml_viewer_mode = false;
+            config.ml_viewer_mode = false;
         }
         let update = Callback::from(move |config| link.send_message(config));
         Self {

--- a/axiom-profiler-GUI/src/filters/mod.rs
+++ b/axiom-profiler-GUI/src/filters/mod.rs
@@ -204,7 +204,7 @@ impl Component for FiltersState {
                 }
                 let link = ctx.link().clone();
                 let cfg = link.get_configuration().unwrap();
-                cfg.update.update(|cfg| { cfg.persistent.ml_viewer_mode = !cfg.persistent.ml_viewer_mode; true });
+                cfg.update.update(|cfg| { cfg.ml_viewer_mode = !cfg.ml_viewer_mode; true });
                 true
             }
         }
@@ -239,7 +239,7 @@ impl Component for FiltersState {
         // TODO: re-add finding matching loops
         let found_mls = ctx.props().file.parser.found_mls;
         let toggle_ml_viewer_mode = ctx.link().callback(|_| Msg::ToggleMlViewerMode); 
-        let ml_viewer_mode = if ctx.link().get_configuration().unwrap().config.persistent.ml_viewer_mode {
+        let ml_viewer_mode = if ctx.link().get_configuration().unwrap().config.ml_viewer_mode {
             html! {
                 <li><a draggable="false" href="#" onclick={toggle_ml_viewer_mode}><div class="material-icons"><MatIcon>{"close"}</MatIcon></div>{"Exit matching loop viewer"}</a></li>
             }
@@ -268,7 +268,7 @@ impl Component for FiltersState {
 
         // Selected nodes
         let selected_nodes = !ctx.props().file.selected_nodes.is_empty();
-        let selected_nodes = (selected_nodes && !ctx.link().get_configuration().unwrap().config.persistent.ml_viewer_mode).then(|| {
+        let selected_nodes = (selected_nodes && !ctx.link().get_configuration().unwrap().config.ml_viewer_mode).then(|| {
             let new_filter = ctx.link().callback(|f| Msg::AddFilter(false, f));
             let nodes = ctx.props().file.selected_nodes.clone();
             let header = format!("Selected {} Node{}", nodes.len(), if nodes.len() == 1 { "" } else { "s" });
@@ -310,7 +310,7 @@ impl Component for FiltersState {
                 <div class="material-icons"><MatIcon>{icon}</MatIcon></div>{action}{d.description()}
             </a> }
         });
-        let normal_mode = if ctx.link().get_configuration().unwrap().config.persistent.ml_viewer_mode {
+        let normal_mode = if ctx.link().get_configuration().unwrap().config.ml_viewer_mode {
             html!{}
         } else {
             html!{

--- a/axiom-profiler-GUI/src/infobars/topbar.rs
+++ b/axiom-profiler-GUI/src/infobars/topbar.rs
@@ -61,7 +61,7 @@ pub fn Topbar(props: &TopbarProps) -> Html {
         indeterminate = false;
     }
     let ml_viewer_mode = use_context::<std::rc::Rc<ConfigurationProvider> >().expect("no ctx found");
-    let omnibox = if ml_viewer_mode.config.persistent.ml_viewer_mode {
+    let omnibox = if ml_viewer_mode.config.ml_viewer_mode {
         html! {
             <MlOmnibox progress={props.progress.clone()} message={props.message.clone()} omnibox={props.omnibox.clone()} found_mls={props.found_mls.unwrap()} pick_nth_ml={props.pick_nth_ml.clone()} />
         }

--- a/axiom-profiler-GUI/src/lib.rs
+++ b/axiom-profiler-GUI/src/lib.rs
@@ -573,6 +573,7 @@ impl Component for FileDataComponent {
                 let Some(filters_state_link) = &*filters_state_link.borrow() else {
                     return;
                 };
+                filters_state_link.send_message(crate::filters::Msg::ClearOperations);
                 filters_state_link.send_message(crate::filters::Msg::AddFilter(false, Filter::SelectNthMatchingLoop(n)));
             }
         }});

--- a/axiom-profiler-GUI/src/results/filters.rs
+++ b/axiom-profiler-GUI/src/results/filters.rs
@@ -112,7 +112,7 @@ impl Filter {
 pub enum FilterOutput {
     LongestPath(Vec<RawNodeIndex>),
     MatchingLoopGeneralizedTerms(Vec<String>),
-    MatchingLoopGraph(Graph<(String, MLGraphNode), ()>),
+    MatchingLoopGraph(Graph<MLGraphNode, ()>),
     None
 }
 

--- a/axiom-profiler-GUI/src/results/graph_info.rs
+++ b/axiom-profiler-GUI/src/results/graph_info.rs
@@ -91,7 +91,7 @@ impl Component for GraphInfo {
             generalized_terms: Vec::new(),
             graph_container: WeakComponentLink::default(),
             displayed_matching_loop_graph: None,
-            in_ml_viewer_mode: msg.config.persistent.ml_viewer_mode,
+            in_ml_viewer_mode: msg.config.ml_viewer_mode,
             _context_listener: context_listener,
         }
     }
@@ -172,8 +172,8 @@ impl Component for GraphInfo {
                 false
             }
             Msg::ContextUpdated(msg) => {
-                if self.in_ml_viewer_mode != msg.config.persistent.ml_viewer_mode {
-                    self.in_ml_viewer_mode = msg.config.persistent.ml_viewer_mode;
+                if self.in_ml_viewer_mode != msg.config.ml_viewer_mode {
+                    self.in_ml_viewer_mode = msg.config.ml_viewer_mode;
                     true
                 } else {
                     false

--- a/smt-log-parser/src/parsers/z3/graph/analysis/mod.rs
+++ b/smt-log-parser/src/parsers/z3/graph/analysis/mod.rs
@@ -25,7 +25,7 @@ pub struct Analysis {
     // // Most to least
     // pub(super) max_depth: Vec<RawNodeIndex>,
     pub matching_loop_end_nodes: Option<Vec<RawNodeIndex>>,
-    pub matching_loop_graphs: Vec<Graph<(String, MLGraphNode), ()>>,
+    pub matching_loop_graphs: Vec<Graph<MLGraphNode, ()>>,
 }
 
 impl Analysis {


### PR DESCRIPTION
As discussed in the meeting of the 16.05.2024, I implemented the feature to disable the filters when the user enters the ML viewer mode.
I also moved the formatting code to the client (no longer in the smt-log-parser) and moved the `ml_viewer_mode: bool` flag to `Configuration` as opposed to `PersistentConfiguration`.