### PR TITLE
removed patch number from rust channel

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.77.0"
+channel = "1.77"
 components = [ "rustfmt", "clippy" ]
 targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
A very small fix. I just removed the patch number from the rust channel in the toolchain file so that cargo, trunk, etc. would behave, as discussed previously.