### PR TITLE
Efficient `RawInstGraph::neighbors_directed`

### DIFF
--- a/axiom-profiler-GUI/src/infobars/topbar.rs
+++ b/axiom-profiler-GUI/src/infobars/topbar.rs
@@ -72,7 +72,11 @@ pub fn Topbar(props: &TopbarProps) -> Html {
             <Omnibox progress={props.progress.clone()} message={props.message.clone()} omnibox={props.omnibox.clone()} search={props.search.clone()} pick={props.pick.clone()} select={props.select.clone()} />
         }
     };
-    let topbar_class = if ml_viewer_mode { "topbar ml-mode" } else { "topbar" };
+    let topbar_class = if ml_viewer_mode {
+        "topbar ml-mode"
+    } else {
+        "topbar"
+    };
     html! {
     <div class={topbar_class}>
         {omnibox}

--- a/smt-log-parser/src/analysis/graph/analysis/mod.rs
+++ b/smt-log-parser/src/analysis/graph/analysis/mod.rs
@@ -2,9 +2,11 @@ pub mod cost;
 pub mod depth;
 pub mod matching_loop;
 pub mod next_insts;
+pub mod next_enabled;
 
 #[cfg(feature = "mem_dbg")]
 use mem_dbg::{MemDbg, MemSize};
+use next_enabled::DefaultNextEnabled;
 use petgraph::Direction;
 
 use crate::{Graph, Result, Z3Parser};
@@ -144,6 +146,8 @@ impl InstGraph {
         self.initialise_transfer(DefaultCost, parser);
         self.initialise_collect(DefaultDepth::<true>, parser);
         self.initialise_collect(DefaultDepth::<false>, parser);
+        self.initialise_transfer(DefaultNextEnabled::<true>, parser);
+        self.initialise_transfer(DefaultNextEnabled::<false>, parser);
 
         self.analyse();
     }

--- a/smt-log-parser/src/analysis/graph/analysis/mod.rs
+++ b/smt-log-parser/src/analysis/graph/analysis/mod.rs
@@ -1,8 +1,8 @@
 pub mod cost;
 pub mod depth;
 pub mod matching_loop;
-pub mod next_insts;
 pub mod next_enabled;
+pub mod next_insts;
 
 #[cfg(feature = "mem_dbg")]
 use mem_dbg::{MemDbg, MemSize};

--- a/smt-log-parser/src/analysis/graph/analysis/next_enabled.rs
+++ b/smt-log-parser/src/analysis/graph/analysis/next_enabled.rs
@@ -115,7 +115,6 @@ impl<const FORWARD: bool> NextEnabledInitialiser<FORWARD> for DefaultNextEnabled
         _idx: usize,
         _incoming: &[Self::Observed],
     ) -> NextInsts {
-        
         match node.disabled() {
             false => NextInsts {
                 nodes: std::iter::once(from_idx).collect(),

--- a/smt-log-parser/src/analysis/graph/analysis/next_enabled.rs
+++ b/smt-log-parser/src/analysis/graph/analysis/next_enabled.rs
@@ -1,0 +1,130 @@
+use std::collections::HashSet;
+
+use petgraph::Direction;
+
+use crate::{
+    analysis::{
+        raw::{NextInsts, Node},
+        RawNodeIndex,
+    },
+    Z3Parser,
+};
+
+use super::{Initialiser, TransferInitialiser};
+
+pub trait NextEnabledInitialiser<const FORWARD: bool> {
+    /// The starting value for a node.
+    fn base(&mut self, node: &Node, parser: &Z3Parser) -> NextInsts;
+    /// Called between initialisations of different subgraphs.
+    fn reset(&mut self) {}
+    type Observed;
+    fn observe(&mut self, node: &Node, parser: &Z3Parser) -> Self::Observed;
+    fn transfer(
+        &mut self,
+        from: &Node,
+        from_idx: RawNodeIndex,
+        to_idx: usize,
+        to_all: &[Self::Observed],
+    ) -> NextInsts;
+}
+impl<C: NextEnabledInitialiser<FORWARD>, const FORWARD: bool> Initialiser<FORWARD, 3> for C {
+    type Value = NextInsts;
+    fn direction() -> Direction {
+        if FORWARD {
+            Direction::Outgoing
+        } else {
+            Direction::Incoming
+        }
+    }
+    fn base(&mut self, _node: &Node, _parser: &Z3Parser) -> Self::Value {
+        NextInsts {
+            nodes: HashSet::default(),
+        }
+    }
+    fn assign(&mut self, node: &mut Node, value: Self::Value) {
+        if FORWARD {
+            node.enabled_parents = value;
+        } else {
+            node.enabled_children = value;
+        }
+    }
+    fn reset(&mut self) {
+        NextEnabledInitialiser::reset(self)
+    }
+}
+impl<C: NextEnabledInitialiser<FORWARD>, const FORWARD: bool> TransferInitialiser<FORWARD, 3> for C {
+    type Observed = C::Observed;
+    fn observe(&mut self, node: &Node, parser: &Z3Parser) -> Self::Observed {
+        NextEnabledInitialiser::observe(self, node, parser)
+    }
+    fn transfer(
+        &mut self,
+        from: &Node,
+        from_idx: RawNodeIndex,
+        to_idx: usize,
+        to_all: &[Self::Observed],
+    ) -> Self::Value {
+        NextEnabledInitialiser::transfer(self, from, from_idx, to_idx, to_all)
+    }
+    fn add(&mut self, node: &mut Node, value: Self::Value) {
+        if FORWARD {
+            node.enabled_parents = NextInsts {
+                nodes: node
+                    .enabled_parents
+                    .nodes
+                    .iter()
+                    .cloned()
+                    .chain(value.nodes.iter().cloned())
+                    .collect(),
+            };
+        } else {
+            node.enabled_children = NextInsts {
+                nodes: node
+                    .enabled_children
+                    .nodes
+                    .iter()
+                    .cloned()
+                    .chain(value.nodes.iter().cloned())
+                    .collect(),
+            };
+        }
+    }
+}
+
+pub struct DefaultNextEnabled<const FORWARD: bool>;
+impl<const FORWARD: bool> NextEnabledInitialiser<FORWARD> for DefaultNextEnabled<FORWARD> {
+    fn base(&mut self, _node: &Node, _parser: &Z3Parser) -> NextInsts {
+        NextInsts {
+            nodes: HashSet::default(),
+        }
+    }
+    type Observed = NextInsts;
+    fn observe(&mut self, node: &Node, _parser: &Z3Parser) -> Self::Observed {
+        if FORWARD {
+            node.enabled_parents.clone()
+        } else {
+            node.enabled_children.clone()
+        }
+    }
+    fn transfer(
+        &mut self,
+        node: &Node,
+        from_idx: RawNodeIndex,
+        _idx: usize,
+        _incoming: &[Self::Observed],
+    ) -> NextInsts {
+        let value = match node.disabled() {
+            false => NextInsts {
+                nodes: std::iter::once(from_idx).collect(),
+            },
+            _ => {
+                if FORWARD {
+                    node.enabled_parents.clone()
+                } else {
+                    node.enabled_children.clone()
+                }
+            }
+        };
+        value
+    }
+}

--- a/smt-log-parser/src/analysis/graph/analysis/next_enabled.rs
+++ b/smt-log-parser/src/analysis/graph/analysis/next_enabled.rs
@@ -52,7 +52,9 @@ impl<C: NextEnabledInitialiser<FORWARD>, const FORWARD: bool> Initialiser<FORWAR
         NextEnabledInitialiser::reset(self)
     }
 }
-impl<C: NextEnabledInitialiser<FORWARD>, const FORWARD: bool> TransferInitialiser<FORWARD, 3> for C {
+impl<C: NextEnabledInitialiser<FORWARD>, const FORWARD: bool> TransferInitialiser<FORWARD, 3>
+    for C
+{
     type Observed = C::Observed;
     fn observe(&mut self, node: &Node, parser: &Z3Parser) -> Self::Observed {
         NextEnabledInitialiser::observe(self, node, parser)

--- a/smt-log-parser/src/analysis/graph/analysis/next_enabled.rs
+++ b/smt-log-parser/src/analysis/graph/analysis/next_enabled.rs
@@ -115,7 +115,8 @@ impl<const FORWARD: bool> NextEnabledInitialiser<FORWARD> for DefaultNextEnabled
         _idx: usize,
         _incoming: &[Self::Observed],
     ) -> NextInsts {
-        let value = match node.disabled() {
+        
+        match node.disabled() {
             false => NextInsts {
                 nodes: std::iter::once(from_idx).collect(),
             },
@@ -126,7 +127,6 @@ impl<const FORWARD: bool> NextEnabledInitialiser<FORWARD> for DefaultNextEnabled
                     node.enabled_children.clone()
                 }
             }
-        };
-        value
+        }
     }
 }

--- a/smt-log-parser/src/analysis/graph/raw.rs
+++ b/smt-log-parser/src/analysis/graph/raw.rs
@@ -226,21 +226,10 @@ impl RawInstGraph {
         Reversed(&*self.graph)
     }
     pub fn neighbors_directed(&self, node: RawNodeIndex, dir: Direction) -> Vec<RawNodeIndex> {
-        let (mut disabled, mut enabled): (Vec<_>, Vec<_>) = self
-            .graph
-            .neighbors_directed(node.0, dir)
-            .map(RawNodeIndex)
-            .partition(|n| self.graph[n.0].disabled());
-        while let Some(next) = disabled.pop() {
-            for n in self.graph.neighbors_directed(next.0, dir).map(RawNodeIndex) {
-                if self.graph[n.0].disabled() {
-                    disabled.push(n);
-                } else {
-                    enabled.push(n);
-                }
-            }
+        match dir {
+            Outgoing => self.graph[node.0].enabled_children.nodes.iter().map(|nx| *nx).collect::<Vec<RawNodeIndex>>(),
+            Incoming => self.graph[node.0].enabled_parents.nodes.iter().map(|nx| *nx).collect::<Vec<RawNodeIndex>>(),
         }
-        enabled
     }
 
     pub fn visible_nodes(&self) -> usize {
@@ -293,6 +282,8 @@ pub struct Node {
     pub inst_parents: NextInsts,
     pub inst_children: NextInsts,
     pub part_of_ml: fxhash::FxHashSet<usize>,
+    pub enabled_parents: NextInsts,
+    pub enabled_children: NextInsts,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -332,6 +323,12 @@ impl Node {
                 nodes: FxHashSet::default(),
             },
             part_of_ml: FxHashSet::default(),
+            enabled_parents: NextInsts {
+                nodes: FxHashSet::default(),
+            },
+            enabled_children: NextInsts {
+                nodes: FxHashSet::default(),
+            },
         }
     }
     pub fn kind(&self) -> &NodeKind {

--- a/smt-log-parser/src/analysis/graph/raw.rs
+++ b/smt-log-parser/src/analysis/graph/raw.rs
@@ -227,8 +227,18 @@ impl RawInstGraph {
     }
     pub fn neighbors_directed(&self, node: RawNodeIndex, dir: Direction) -> Vec<RawNodeIndex> {
         match dir {
-            Outgoing => self.graph[node.0].enabled_children.nodes.iter().map(|nx| *nx).collect::<Vec<RawNodeIndex>>(),
-            Incoming => self.graph[node.0].enabled_parents.nodes.iter().map(|nx| *nx).collect::<Vec<RawNodeIndex>>(),
+            Outgoing => self.graph[node.0]
+                .enabled_children
+                .nodes
+                .iter()
+                .map(|nx| *nx)
+                .collect::<Vec<RawNodeIndex>>(),
+            Incoming => self.graph[node.0]
+                .enabled_parents
+                .nodes
+                .iter()
+                .map(|nx| *nx)
+                .collect::<Vec<RawNodeIndex>>(),
         }
     }
 

--- a/smt-log-parser/src/analysis/graph/raw.rs
+++ b/smt-log-parser/src/analysis/graph/raw.rs
@@ -230,14 +230,12 @@ impl RawInstGraph {
             Outgoing => self.graph[node.0]
                 .enabled_children
                 .nodes
-                .iter()
-                .map(|nx| *nx)
+                .iter().copied()
                 .collect::<Vec<RawNodeIndex>>(),
             Incoming => self.graph[node.0]
                 .enabled_parents
                 .nodes
-                .iter()
-                .map(|nx| *nx)
+                .iter().copied()
                 .collect::<Vec<RawNodeIndex>>(),
         }
     }

--- a/smt-log-parser/src/analysis/graph/raw.rs
+++ b/smt-log-parser/src/analysis/graph/raw.rs
@@ -230,12 +230,14 @@ impl RawInstGraph {
             Outgoing => self.graph[node.0]
                 .enabled_children
                 .nodes
-                .iter().copied()
+                .iter()
+                .copied()
                 .collect::<Vec<RawNodeIndex>>(),
             Incoming => self.graph[node.0]
                 .enabled_parents
                 .nodes
-                .iter().copied()
+                .iter()
+                .copied()
                 .collect::<Vec<RawNodeIndex>>(),
         }
     }


### PR DESCRIPTION
When I implemented a disabler to disable all the Instantiation-nodes, I noticed that the code got stuck trying to find all outgoing enabled successors of a node (this was with [heaps-simpler3.log](https://github.com/user-attachments/files/15624199/heaps-simpler3.log)). After a detailed analysis, I noticed that the code got stuck in `InstGraph::analyse`, more specifically, when calling `self.raw.neighbors_directed` on the node `=2`.

I found out that the issue was that in a graph like the one in the screenshot, if all successors of the top-most (white) node `=2` are disabled, it will essentially iterate through all paths in `RawInstGraph::neighbors_directed`. In cases like the one shown in the screenshot, this will result in an exponential number of paths searched through and hence it gets stuck. 

<img width="301" alt="image" src="https://github.com/viperproject/axiom-profiler-2/assets/23278394/e0b8efef-79c5-42ba-a68f-ac094879e740">

To fix this, I added an efficient pre-computation to find the next enabled nodes (in either direction) right before the analysis in `InstGraph::initialise_default` such that subsequently in the analysis, we only have to access this field. To this end, I re-used the `TransferInitialiser` that iterates through the graph in a DP-manner (in topological order for parents and reverse topological order for children) to compute the next enabled children and parents of a node. The code should be rather self-explanatory.

I have tested the code with assertions to see whether the computed neighbours match with the previous version and it did. One thing I'm not sure of is if `InstGraph::initialise_default` is the right place to call this function.