### PR TITLE
Fix performance issue related to analysis sort

### DIFF
--- a/axiom-profiler-GUI/src/filters/add_filter.rs
+++ b/axiom-profiler-GUI/src/filters/add_filter.rs
@@ -71,9 +71,8 @@ pub fn AddFilterSidebar(props: &AddFilterSidebarProps) -> Html {
                 .filter(|&(n, _, _)| {
                     graph
                         .raw
-                        .neighbors_directed(n, Direction::Outgoing)
-                        .into_iter()
-                        .any(|n| graph.raw[n].hidden())
+                        .neighbors_directed_count_hidden(n, Direction::Outgoing)
+                        > 0
                 })
                 .map(|(n, _, _)| Filter::ShowNeighbours(n, Direction::Outgoing))
                 .collect(),
@@ -82,9 +81,8 @@ pub fn AddFilterSidebar(props: &AddFilterSidebarProps) -> Html {
                 .filter(|&(n, _, _)| {
                     graph
                         .raw
-                        .neighbors_directed(n, Direction::Incoming)
-                        .into_iter()
-                        .any(|n| graph.raw[n].hidden())
+                        .neighbors_directed_count_hidden(n, Direction::Incoming)
+                        > 0
                 })
                 .map(|(n, _, _)| Filter::ShowNeighbours(n, Direction::Incoming))
                 .collect(),

--- a/axiom-profiler-GUI/src/results/filters.rs
+++ b/axiom-profiler-GUI/src/results/filters.rs
@@ -89,7 +89,7 @@ impl Filter {
             Filter::MaxInsts(n) => graph.keep_first_n_cost(n),
             Filter::MaxBranching(n) => graph.keep_first_n_children(n),
             Filter::ShowNeighbours(nidx, direction) => {
-                let nodes = graph.raw.neighbors_directed(nidx, direction);
+                let nodes = graph.raw.neighbors_directed_collect(nidx, direction);
                 graph.raw.set_visibility_many(false, nodes.into_iter())
             }
             Filter::VisitSubTreeWithRoot(nidx, retain) => {

--- a/axiom-profiler-GUI/src/results/node_info.rs
+++ b/axiom-profiler-GUI/src/results/node_info.rs
@@ -275,8 +275,8 @@ pub fn SelectedNodesInfo(
                     <InfoLine header="To Leaf" text={format!("short {}, long {}", info.node.bwd_depth.min, info.node.bwd_depth.max)} code=false />
                     <InfoLine header="Degree" text={
                         format!("parents {}, children {}",
-                            graph.raw.neighbors_directed(node, petgraph::Direction::Incoming).len(),
-                            graph.raw.neighbors_directed(node, petgraph::Direction::Outgoing).len()
+                            graph.raw.neighbors_directed_count(node, petgraph::Direction::Incoming),
+                            graph.raw.neighbors_directed_count(node, petgraph::Direction::Outgoing),
                         )
                     } code=false />
                 </ul>

--- a/smt-log-parser/src/analysis/graph/analysis/mod.rs
+++ b/smt-log-parser/src/analysis/graph/analysis/mod.rs
@@ -159,10 +159,9 @@ impl InstGraph {
                 .reverse()
                 .then_with(|| a.cmp(&b))
         });
-        self.analysis.children.sort_by(|&a, &b| {
-            let ac = self.raw.neighbors_directed(a, Direction::Outgoing).len();
-            let bc = self.raw.neighbors_directed(b, Direction::Outgoing).len();
-            ac.cmp(&bc).reverse().then_with(|| a.cmp(&b))
+        self.analysis.children.sort_by_cached_key(|&a| {
+            let ac = self.raw.neighbors_directed_count(a, Direction::Outgoing);
+            (usize::MAX - ac, a)
         });
         self.analysis.fwd_depth_min.sort_by(|&a, &b| {
             self.raw.graph[a.0]

--- a/smt-log-parser/src/analysis/graph/visible.rs
+++ b/smt-log-parser/src/analysis/graph/visible.rs
@@ -39,21 +39,15 @@ impl InstGraph {
         // mapping from old node index to new node index, end represents removed.
         let mut node_index_map = vec![NodeIndex::end(); self.raw.graph.node_count()];
         let node_map = |idx, node: &Node| {
-            node.visible().then(|| VisibleNode {
-                idx,
-                hidden_parents: self
-                    .raw
-                    .neighbors_directed(idx, Direction::Incoming)
-                    .into_iter()
-                    .filter(|n| self.raw.graph[n.0].hidden())
-                    .count() as u32,
-                hidden_children: self
-                    .raw
-                    .neighbors_directed(idx, Direction::Outgoing)
-                    .into_iter()
-                    .filter(|n| self.raw.graph[n.0].hidden())
-                    .count() as u32,
-                max_depth: 0,
+            node.visible().then(|| {
+                let hidden_parents = self.raw.neighbors_directed_count_hidden(idx, Incoming);
+                let hidden_children = self.raw.neighbors_directed_count_hidden(idx, Outgoing);
+                VisibleNode {
+                    idx,
+                    hidden_parents: hidden_parents as u32,
+                    hidden_children: hidden_children as u32,
+                    max_depth: 0,
+                }
             })
         };
         for (i, node) in self.raw.graph.node_weights().enumerate() {


### PR DESCRIPTION
The issue is that the call to `self.analysis.children.sort_by` was really slow due to having to recalculate `neighbors_directed` each time